### PR TITLE
Add Markdown docs for install and key man pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Thu Apr 19 23:25:43 PST 1979
 
 For installation instructions:
 
-        nroff -ms install.ms
+        docs/install_full.md
 
 Subdirectories:
         bin             Binaries for standard version 6 systems
         doc             Source for documents
         man             Source for manual pages
-        misc            A few miscellaneous files (see install.ms)
+        misc            A few miscellaneous files (see docs/install_full.md)
         src             Source for programs/troff macros
         upgrade         doc/man/src/include for version 6 systems
 
@@ -123,7 +123,7 @@ make test     # runs ./tests/run_tests.sh
 Installation & Usage
 	1.	Format the installation notes and follow them:
 
-nroff -ms install.ms | more
+docs/install_full.md
 
 
 	2.	Install binaries to your UNIX V6 target (or emulator disk image).
@@ -137,14 +137,15 @@ qemu-system-i386 -serial mon:stdio \
 
 
 
-Detailed, step-by-step instructions are in docs/INSTALL.md; runtime tips are in docs/USAGE.md.
+Detailed instructions are in docs/INSTALL.md; the full historical text is in docs/install_full.md. Runtime tips are in docs/USAGE.md.
 
 ⸻
 
 Documentation
 	•	docs/INSTALL.md — Installation guide
+        •       docs/install_full.md — Original installation notes
 	•	docs/USAGE.md   — Running & testing tips
-	•	man/             — Modernized manual pages (HTML/PDF)
+	•	man/             — Modernized manual pages (Markdown)
 	•	legacy/          — Raw troff archives from the original tape
 
 ⸻

--- a/docs/install_full.md
+++ b/docs/install_full.md
@@ -1,0 +1,360 @@
+Second Distribution of Berkeley Software for UNIX†
+
+Installation Instructions
+
+† UNIX is a trademark of Bell Laboratories.
+
+By following the directions here you should be able to bring up the
+software on the tape in a very short period of time, ranging from an
+hour (if you have a standard version 6 system and can use the
+precompiled binaries), to about 6 hours (if you have a version 6 or 7
+system which requires recompilation.)
+
+# Extracting the tape
+
+To extract the tape you will need a 800 BPI tape drive and a file system
+with 12000 blocks of free space. If your tape was written with *tar* or
+*cpio*, then extracting the tape is straightforward. If it was written
+with *tp* (the default) then some work will be required to fully unpack
+the tape. Unless you will be using *tp* here skip the next paragraph.
+
+First extract the file **create** from the tape by doing:
+
+tp xm ./create
+
+This is a shell script of **mkdir** commands. Run the script and then do
+
+tp xm
+
+This will take several minutes. When it completes, you will have a
+skeletal tape. In most directories on the tape will be a file **cont.a**
+which is an archive of the contents of that directory. The best thing to
+do is to unarchive all the files so you can look at things easily. The
+find command
+
+find . -name cont.a -a -print
+
+will print the names of all the **cont.a** files. For each such file,
+change into its directory and do
+
+ar x cont.a rm cont.a
+
+You can omit the **rm** if you have tons of space. If you have a very
+old *ar*, you may have to use the *ar* in **misc**.
+
+# Installation Preparation
+
+The first thing to determine is which version of UNIX you are running,
+and how much impact modifications you have made to the system will have
+on the software here.
+
+# Version 7
+
+This is the new version of UNIX which has just been released by Bell
+Laboratories. Most of the software here has been running on version 7
+for several months at Berkeley.
+
+The binaries on the distribution tape will NOT run on version 7, as they
+were compiled on a PDP-11 version 6 system. Thus you must recompile from
+the source for a version 7 system. This will not be hard since almost
+all of the software thinks it is running on version 7. The one exception
+is the Pascal system, which has not been run on version 7 (since we
+don\'t have version 7 on our PDP-11s yet).
+
+# Version 6
+
+If you have a standard version 6 UNIX system then you can just use the
+binaries on the tape and avoid the bother of recompiling. In fact,
+unless you have a late-model C compiler compilation may be troublesome
+or impossible.
+
+On a \`\`standard\'\' system the *getuid* system call returns the user
+id in the low byte of its result word. If this is the case on your
+system, then you should have no trouble installing the binaries
+supplied.†
+
+† I have compiled the code here with a library which uses \`\`sys
+sleep\'\' to implement *sleep()*, rather than the later, more efficient
+sleep implementation using new system calls pause and alarm. If you have
+the latter, you can recompile programs which sleep if you wish.
+
+# Other Version 6
+
+If you have a version 6 UNIX system which has 16 bit user id\'s (such as
+the systems at Berkeley) then you will have to modify the
+**upgrade/libretro** version 7 simulator library and recompile the
+programs here.
+
+If you have a PWB/UNIX system, the binaries supplied here should work
+(as far as I know). If they don\'t the *make* and *cc* from PWB should
+be adequate to recompile to repair any problems.
+
+# New files to be added.
+
+The following are the major files and directories which will be created
+as you install the tape:
+
+:   This is the new shell. It is not placed in the directory
+    **/usr/ucb** because it is often linked to **/bin/makesh**, which is
+    on a different file system than **/usr/ucb** on most systems.
+
+:   For version 6 systems, this forms a data base which simulates
+    version 7 environments, storing home directories and (most
+    importantly) terminal types for each terminal.
+
+:   This is a data base describing terminals, and is used by the *ex*
+    editor, and the *tset* program.
+
+:   This file maps terminal ports to their types, and indicates which
+    ports are not hard wired. The *tset* program uses this to initialize
+    the terminal type at login.
+
+:   On version 6 systems, a directory of header files used to simulate
+    version 7 UNIX.
+
+:   Help files for *Mail*.
+
+:   A startup file for *Mail*.
+
+:   Preserve command for *ex*.
+
+:   Recover command for *ex*.
+
+:   Error messages for *ex*.
+
+:   Help files for Pascal.
+
+:   Library simulating some version 7 calls on version 6.
+
+:   Library providing terminal independent functions.
+
+:   \[Directory\] The dynamically loaded parts of the *-me* macros are
+    placed here.
+
+:   Error messages for *pi*, the Pascal translator.
+
+:   Messages for two process *pi* for 34\'s and 40\'s.
+
+:   Second pass of two process *pi* translator.
+
+:   Header files which *pi* prepends to *obj* files.
+
+:   \[Directory\] Terminal initialization files for *tset*.
+
+:   The *-me* macros themselves, on version 6 systems.
+
+:   The *-me* macros themselves, on version 7 systems.
+
+:   \[Directory\] The *msgs* program places messages here.
+
+:   \[Directory\] Editor temporaries are preserved here after system
+    crashes.
+
+:   \[Directory\] Most of the binaries on the tape are placed here. They
+    can be linked elsewhere (i.e. **/usr/bin**) but the makefiles which
+    create the tape software expect them in **/usr/ucb** so they should
+    be left there also.
+
+# Installation procedure.
+
+Now follow the following procedure:
+
+1.  Run the **setup** script in this directory to create needed files
+    and directories.
+
+2.  If you have a version 6 system then run the **install** script in
+    the directory **upgrade/include** to put a copy of the retrofitting
+    header files in **/usr/include/retrofit**.
+
+3.  If you have a standard version 6 system (with 8 bit user id\'s) then
+    run the **install** script in the directory **bin** on the tape.
+    Then skip to step 6.
+
+4.  If you have a non-standard version 6 system which uses 16 bit
+    user-id\'s or has other modifications which would destroy binary
+    compatibility, then:
+
+    a.  Look at the retrofit library source directory
+        **upgrade/libretro** and make needed changes. Recreate the
+        library and install it. If you have *make* you can use the
+        **makefile**; otherwise use your shell with **make.script**.
+
+    b.  Recompile the termlib library **src/termlib**, using
+        **makefile.v6** and \`\`make install\'\', or the shell script
+        **make.script** if you don\'t have *make*.
+
+    c.  Recompile the programs in **upgrade/src** using **make.script**
+        or **makefile**. These are versions of some programs in **src**
+        which are different for version 6.
+
+    d.  Follow the rest of the instructions for making a version 7
+        compilation, using **makefile.v6** or **make.script** whenever
+        they exist rather than **makefile**. (You can skip part *a*
+        since you have done it already.)
+
+5.  If you have a version 7 system:
+
+    a.  Run *make* in **src/termlib**, since this makes an important
+        library which you will need right away.
+
+    b.  Then start in the **src** directory, and run *make* there and
+        then in each subdirectory (see below). Look at the **READ_ME**
+        files in each directory to get an idea of what is going on.
+        After creating the binaries \`\`make install\'\' will install
+        them in **/usr/ucb**. Some makefiles also install things in
+        **/usr/lib/** or **/etc**; use \`\`make -n\'\' to see what
+        *make* will do.
+
+        The following is a reasonable order to do the subdirectories in:
+        (omitting Pascal for now):
+
+    Mail, csh, ex, me
+
+    c.  Install the Pascal system. Some of the parts of the Pascal
+        system will require special treatment on version 7 as they use
+        the older i/o library of version 6. See the file
+        **misc/v7pascal** for more details.
+
+        It is not necessary to compile **eyacc** or to run *eyacc* in
+        the **pi** and **pxp** directories; rather just use the supplied
+        **y.tab.c** files. (The supplied **makefile**s don\'t run
+        *eyacc*.)
+
+    d.  Now prepare the utilities for the Pascal system in the directory
+        **pascal**. Then prepare the Pascal translator **pi**, the
+        interpreter **px** and, finally, the profiler **pxp**.
+
+        If you have a non-separate I/D machine, or if you do not have
+        hardware floating point, then prepare **pi0** and **pi1** rather
+        than **pi**, and use the **px34** and **pxp34** (NOID) versions
+        of *px* and *pxp*.†
+
+    † You can run *pi* (instead of *pi34* from **pi0** and **pi1**) on a
+    non-floating point machine with separate I/D by adding a system call
+    to simulate a mfpi instruction (see **misc/fetchi.sys**). This *pi*
+    will run slightly faster, and allow slightly larger programs to be
+    written.
+
+    You should, on these machines:
+
+    mv /usr/ucb/pi34 /usr/ucb/pi mv /usr/ucb/px34 /usr/ucb/px mv
+    /usr/ucb/pxp34 /usr/ucb/pxp
+
+6.  Install the manual sections in **man** copying them to
+    **/usr/man/manu**. If you have version 6, follow the instructions in
+    **upgrade/man** on adapting to the different manual macros used.
+
+7.  Add a line of the form
+
+/usr/lib/ex2.0preserve -a
+
+to the file **/etc/rc**, before it cleans files out of **/tmp**. This
+will preserve the editor temporaries from **/tmp** after system crashes,
+and implements the editor crash recovery mechanism.†
+
+† If **/usr** is a mounted filesystem, be sure it is mounted before you
+try to run **/usr/lib/ex2.0preserve**.
+
+7.  So that the *msgs* program can receive messages which are sent via
+    **mail** change, change your mail program to execute
+    \`\`/usr/ucb/msgs -s\'\' with the message on the standard input
+    whenever mail is sent to \`\`msgs\'\'. A version 6 **mail** program
+    which does this is in \`\`mail.c\'\' in the directory **misc**.
+
+8.  Make sure that the programs **/usr/lib/ex2.0preserve** and
+    **/usr/lib/ex2.0recover** can write the directory **/usr/preserve**.
+    For security, these programs should be owned by \`\`root\'\', mode
+    4755, and the directory **/usr/preserve** should be mode 755.
+
+    The programs **/usr/ucb/setenv** and **/usr/ucb/tset** must be able
+    to write **/etc/htmp**. It is wise to have **/etc/htmp** mode 644
+    and **sethome** and **ttytype** mode 4755 to a user who owns
+    **/etc/htmp** (this doesn\'t have to be \`\`root\'\', but it can).
+
+9.  Initialize the **/etc/ttytype** data base with the types of the
+    terminals on your system. The file contains one line per terminal.
+    On version 6, each line has the (one character) terminal name, and
+    then a 2 character code. On version 7 each line has a two character
+    code, a space, and then the (arbitrary length) terminal name. See
+    **misc/ttytype.v6** and **misc/ttytype** for samples. The codes are
+    defined by the file **/etc/termcap**.
+
+10. Initialize the Mail file **/usr/lib/Mail.rc** defining any *alias*
+    groups for distribution of mail you wish. A line of the form
+
+alias staff bill kurt eric
+
+will cause \`\`Mail staff\'\' to send copies to *bill*, *kurt*, and
+*eric*.
+
+# Software not installed by the above procedure
+
+The modifications to the standard i/o library **src/libNS**, the
+Berkeley network **src/net**, and the *finger* program **src/finger.c**
+are not installed by the above procedure.
+
+The standard I/O library modifications may require some care to make as
+several slightly different versions of this library are extant. See the
+**READ_ME** file in the **src/libNS** directory.
+
+If you wish to run the Berkeley network, read the material in the
+**src/net** directory. The network is not hard to set up, but this will
+require a bit of preparation.
+
+The *finger* program requires preparation of some data bases, and
+perhaps modifications to the *login* program as well as to *finger*
+itself to work. See the comments at the beginning of the program
+**src/finger.c** and its manual page for details.
+
+# Problems you may encounter (Version 6 only)
+
+1.  Recompiling the editor will overflow the standard compiler symbol
+    table. See **upgrade/c** for instructions on a trivial change to
+    make a C compiler with a bigger symbol table, which you can make
+    available via the **-t0** flag to **cc**. Some scripts on the tape
+    also reference a **-t1** version of the C compiler, which puts
+    *switch* statement code out as instructions rather than as data.
+    This makes for programs with larger text spaces but smaller per-user
+    data. See **upgrade/c** for the C compiler change which implements
+    this.
+
+2.  If you use the binaries on the tape, some will print times in
+    Pacific time. They will work in your time zone if you recompile
+    them.
+
+3.  *Csh* uses an *access* system call which is not part of a bare
+    version 6 system. Its manual page and C interface are in the
+    directory **misc**, as well as a file **access.sys** containing
+    information on how to add it to your system. The *access* call is in
+    later version 6 and version 7 systems.
+
+4.  If you don\'t get mail in the file \`\`.mail\'\' in your login
+    directory you\'ll have to finagle the *Mail* program to know where
+    you do. Look at its **local.c** and **local.h** files. The *from*
+    program in **upgrade/src** will also have to be changed.
+
+5.  If you have changed the *times* system call as per 50 changes,
+    returning long integers for *proc_user_time* and *proc_system_time*,
+    the supplied *csh* binary will dump when it calls *times*. You\'ll
+    have to change some declarations in the shell and recompile.
+
+# Maintenance
+
+:   If you get have or get terminals which aren\'t described in this
+    data base, you will have to add entries. The manual page for
+    *termcap* explains how to write new entries.
+
+:   This file tells the types of hardwired ports and which lines are
+    dialups, and is used with *tset*. It must be edited when the system
+    configuration changes.
+
+:   Editor temporaries are saved here after a system crash, when
+    /usr/lib/ex2.0preserve is run out of /etc/rc. If no one cleans this
+    directory out, it can get very large. You can periodically run a
+    find command of the form
+
+find /usr/preserve -mtime +7 -a -exec rm -f {} \\;
+
+to clean out old junk. It is usefully run by the daemon *cron*.
+
+:   Must be cleaned out periodically (every few months).

--- a/man/finger.md
+++ b/man/finger.md
@@ -1,0 +1,119 @@
+# NAME
+
+finger - user information lookup program
+
+# SYNOPSIS
+
+**finger** \[ **-bfhilmpqsw** \] login \...
+
+# DESCRIPTION
+
+*Finger* lists the login name, full name, terminal name and write status
+(as a \'\*\' before the terminal name if write permission is denied),
+idle time, login time, and office location and phone number (if they are
+known) for each current UNIX user, examining the /etc/utmp, /etc/passwd,
+and /usr/adm/lastlog files to obtain its information.
+
+*Finger* takes control arguments, preceded by a dash, followed by an
+optional list of login names. With no list of login names, the list of
+users currently logged on is used.
+
+*Finger* has three output modes - quick, short and long. In quick mode,
+data is only retrieved from /etc/utmp, providing only login name,
+terminal name, and login time in a format similar to *who*(1). In short
+mode, *finger* gives a one line per user output containing login name,
+full name, terminal name and write status (a \'\*\' before the terminal
+name indicates write permission is denied), idle time (the time since
+the user last typed anything meaningful), login time, and office
+location and phone number (if the user is logged in on a dialup, her
+home phone number is printed instead of office and office phone). Any
+items not found are omitted. The format for the idle time is minutes, if
+it is a single integer, hours and minutes if a \':\' is present, or days
+and hours if a \'d\' is present. Long mode causes *finger* to print all
+the information that short mode gives in a multi-line, easy to read
+format. In addition, it also prints the users home directory and login
+shell, and, if a file .plan exists in her home directory, it is printed
+in its entirety; if a file .project exits in her home directory its
+first line is printed.
+
+The control arguments to *finger* have the following effect:
+
+**-b**
+
+:   When doing long format output, suppress the printing of the home
+    directory and shell fields.
+
+**-f**
+
+:   Suppress the printing of the header line when doing quick or short
+    style outputs.
+
+**-h**
+
+:   Suppress the printing of .project files when doing long style
+    outputs.
+
+**-i**
+
+:   Do a quick style output, but also lookup idle times and terminal
+    status.
+
+**-l**
+
+:   Force long style format; this option only has effect if no login
+    name list is given (since it is the default if a list is given).
+
+**-m**
+
+:   Instead of just comparing the listed names with all login names, the
+    \"-m\" option also forces comparison with the user\'s real names
+    stored in the gecos field of /etc/passwd. This allows you, for
+    example, to find all users that have a first name of \`\`bill\'\' or
+    a last name of \`\`cooper\'\', for example.
+
+**-p**
+
+:   Suppress the printing of .plan files when doing long style outputs.
+
+**-q**
+
+:   Force quick style outputs.
+
+**-s**
+
+:   Force short style outputs; this option only has effect if a name
+    list is given (since it is the default if none is given).
+
+**-w**
+
+:   Decrease the width of short style outputs (by removing the name
+    field) for narrow displays.
+
+*Finger* is smart about a user being logged in more than once, and will
+do separate lookups for each terminal on which a user is logged in.
+
+The only problem with *finger* is one of unportability; the source of
+the information *finger* uses is the gecos field of /etc/passwd, which
+UCB VAX/UNIX uses for comment information on the user.
+
+# FILES
+
+/etc/utmp who file\
+/etc/passwd for users names, offices, phones, directories and shells\
+/usr/adm/lastlog last login times\
+\~/.plan plans\
+\~/.project projects
+
+# SEE ALSO
+
+who(1)
+
+# BUGS
+
+/usr/adm/lastlog is a local addition at UCB. If no equivalent is present
+then finger would have to look backwards through /usr/adm/wtmp, which
+would be very slow.
+
+# AUTHOR
+
+Earl T. Cohen

--- a/man/man.md
+++ b/man/man.md
@@ -1,0 +1,55 @@
+# NAME
+
+man - run of section of UNIX manual
+
+# SYNOPSIS
+
+**man** \[ **-** \] \[ **-t** \] \[ section \] title \...
+
+# DESCRIPTION
+
+*Man* is a program which prints sections of the manual. *Section* is an
+option arabic section number, i.e. 3, which may be followed by a single
+letter classifier, i.e. 1m indicating a maintenance type program in
+section 1. It may also be \`\`ucb\'\', \`\`sccs\'\', or \`\`public\'\'.
+If a section specifier is given *man* looks in the that section of the
+manual for the given *titles.* If *section* is omitted, *man* searches
+all sections of the manual, giving preference to commands over
+subroutines in system libraries, and printing the first section it
+finds, if any. The command *apropos*(UCB) can help find a command whose
+name has been forgotten, looking it up by kewords in its \`\`one
+line\'\' description.
+
+If the standard output is a teletype, or if the flag **-** is given,
+then *man* pipes its output through *ssp*(UCB) to crush out useless
+blank lines, and through *cr3*(UCB) to stop after each page on the
+screen. Hit a carriage return to continue, a control-D to scroll 12 more
+lines when the output stops.
+
+The **-t** flag causes *man* to arrange for the specified section to be
+*troff\'ed* to the Versatec.
+
+# FILES
+
+/usr/man/man?/\*
+
+# SEE ALSO
+
+apropos(UCB), cr3(UCB), ssp(UCB), whereis(UCB)
+
+# AUTHOR
+
+Bill Joy
+
+# BUGS
+
+The manual is supposed to be reproducible either on the phototypesetter
+or on a typewriter. However, on a typewriter some information is
+necessarily lost.
+
+If multiple sections of the manual are to be *troff\'ed* then it is
+better to run them off with *vtroff*(UCB)*using*a*sequence*like
+
+> cd /usr/man/mann; vtroff -man mail.n msgs.n
+
+since the pages will then be run in one Versatec job using less paper.


### PR DESCRIPTION
## Summary
- convert legacy `install.ms` to `docs/install_full.md`
- convert `man` and `finger` troff pages to Markdown
- link new docs from README and update documentation list

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688af76d59408331a46d307547f25dae

## Summary by Sourcery

Convert the legacy troff-based installation instructions and manual pages to Markdown, add the new docs/install_full.md and man/*.md files, and update README.md to link to these Markdown docs.

Enhancements:
- Convert legacy install.ms to a new Markdown document at docs/install_full.md
- Convert the finger and man troff manual pages to corresponding Markdown files in man/
- Update README.md to reference the new Markdown installation and manual pages and refresh the documentation list