### PR TITLE
Add shell test harness with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
-name: C CI
+name: CI
 
 on:
   push:
+    branches: [ main ]
   pull_request:
 
 jobs:
@@ -9,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install build tools
+      - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential
       - name: Run tests
-        run: |
-          make test
+        run: make test

--- a/tests/harness.sh
+++ b/tests/harness.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# harness.sh - simple shell-based test utilities
+#
+# Provides helpers for compiling minimal utilities and asserting
+# expected output. Each test script may source this file.
+
+set -e
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+TMP_DIR="$ROOT_DIR/tests/tmp"
+mkdir -p "$TMP_DIR"
+
+failures=0
+
+# compile_utils util1 util2 ...
+#   Compiles each src/<util>.c into build/<util>
+compile_utils() {
+    mkdir -p "$ROOT_DIR/build"
+    CC=${CC:-gcc}
+    CFLAGS=${CFLAGS:--Icompat -Wall -Wextra -O2}
+    for u in "$@"; do
+        $CC $CFLAGS "$ROOT_DIR/src/$u.c" -o "$ROOT_DIR/build/$u"
+    done
+}
+
+# run_test test_script
+#   Executes a test script and records failure
+run_test() {
+    sh "$1" || failures=$((failures + 1))
+}
+
+# assert_equal expected cmd...
+#   Runs cmd and compares its output to expected string
+assert_equal() {
+    expected="$1"
+    shift
+    output="$("$@")"
+    if [ "$output" != "$expected" ]; then
+        echo "expected '$expected', got '$output'" >&2
+        return 1
+    fi
+    return 0
+}
+
+finish() {
+    if [ $failures -eq 0 ]; then
+        echo "All tests passed."
+    else
+        echo "$failures tests failed." >&2
+    fi
+    return $failures
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,51 +1,15 @@
 #!/bin/sh
 set -e
-# compile and run tests
+
 DIR=$(cd "$(dirname "$0")/.." && pwd)
-cd "$DIR"
+. "$DIR/tests/harness.sh"
 
-mkdir -p build
-CC=${CC:-gcc}
-CFLAGS="-Icompat -Wall -Wextra -O2"
+compile_utils whoami head expand printenv
 
-UTILS="whoami head expand printenv"
-for u in $UTILS; do
-    $CC $CFLAGS src/$u.c -o build/$u
+for t in "$DIR"/tests/test_*.sh; do
+    echo "Running $(basename "$t")"
+    run_test "$t"
 done
 
-mkdir -p tests/tmp
-fail=0
-
-# whoami
-expected=$(id -un)
-output=$(build/whoami)
-[ "$output" = "$expected" ] || { echo "whoami failed: $output"; fail=1; }
-
-# head
-printf "a\nb\nc\n" >tests/tmp/file
-build/head -2 tests/tmp/file >tests/tmp/out
-printf "a\nb\n" >tests/tmp/expected
-if ! diff -u tests/tmp/expected tests/tmp/out; then
-    echo "head failed"; fail=1
-fi
-
-# expand
-printf "a\tb\n" >tests/tmp/tabs
-build/expand tests/tmp/tabs >tests/tmp/out
-printf "a       b\n" >tests/tmp/expected
-if ! diff -u tests/tmp/expected tests/tmp/out; then
-    echo "expand failed"; fail=1
-fi
-
-# printenv
-build/printenv PATH >tests/tmp/out
-if ! [ -s tests/tmp/out ]; then
-    echo "printenv failed"; fail=1
-fi
-
-if [ $fail -eq 0 ]; then
-    echo "All tests passed."
-else
-    echo "Some tests failed." >&2
-fi
-exit $fail
+finish
+exit $?

--- a/tests/test_expand.sh
+++ b/tests/test_expand.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+. "$(dirname "$0")/harness.sh"
+
+printf 'a\tb\n' > "$TMP_DIR/tabs"
+"$ROOT_DIR/build/expand" "$TMP_DIR/tabs" > "$TMP_DIR/out"
+printf 'a       b\n' > "$TMP_DIR/exp"
+if ! diff -u "$TMP_DIR/exp" "$TMP_DIR/out"; then
+    exit 1
+fi

--- a/tests/test_head.sh
+++ b/tests/test_head.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+. "$(dirname "$0")/harness.sh"
+
+printf 'a\nb\nc\n' > "$TMP_DIR/in"
+"$ROOT_DIR/build/head" -2 "$TMP_DIR/in" > "$TMP_DIR/out"
+printf 'a\nb\n' > "$TMP_DIR/exp"
+if ! diff -u "$TMP_DIR/exp" "$TMP_DIR/out"; then
+    exit 1
+fi

--- a/tests/test_printenv.sh
+++ b/tests/test_printenv.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/harness.sh"
+
+"$ROOT_DIR/build/printenv" PATH > "$TMP_DIR/out"
+[ -s "$TMP_DIR/out" ]

--- a/tests/test_whoami.sh
+++ b/tests/test_whoami.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/harness.sh"
+
+expected=$(id -un)
+assert_equal "$expected" "$ROOT_DIR/build/whoami"


### PR DESCRIPTION
## Summary
- create a simple shell harness for regression tests
- split tests per utility and use the new harness
- run tests via GitHub Actions CI

## Testing
- `./tests/run_tests.sh`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688af76a251083318f24545d3cb9e63d

## Summary by Sourcery

Add a shell-based test harness, split regression tests per utility, and integrate the suite into CI

New Features:
- Introduce a shell test harness with compile_utils, run_test, assert_equal, and finish helpers
- Add individual regression test scripts for whoami, head, expand, and printenv

Enhancements:
- Refactor tests/run_tests.sh to source the harness and iterate over per-utility test scripts

CI:
- Update GitHub Actions workflow to install dependencies, restrict to main branch, and run make test

Tests:
- Add tests/harness.sh and modular test_*.sh scripts under the tests directory