### PR TITLE
docs: link markdown install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,11 @@ make test     # runs ./tests/run_tests.sh
 ⸻
 
 Installation & Usage
-	1.	Format the installation notes and follow them:
+	1.      Read **docs/INSTALL.md** for a concise Markdown summary of the tape's setup procedure. The original troff source is available as `legacy/install.ms` and can be formatted with:
 
-nroff -ms install.ms | more
+```sh
+  nroff -ms legacy/install.ms | more
+```
 
 
 	2.	Install binaries to your UNIX V6 target (or emulator disk image).


### PR DESCRIPTION
## Summary
- link to docs/INSTALL.md in README
- include note about formatting legacy install.ms

## Testing
- `make test` *(fails: retrofit.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_688af7246b108331874301d4b72fa828