### PR TITLE
Add build helper script with profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ Many of the subdirectories still contain their original makefile written for V7 
 
 2. Modern build.sh Profiles
 
-For an even simpler one-command build, use our Bash helper:
+The `build.sh` script walks every subdirectory under `src/` and `upgrade/`,
+invoking each Makefile it finds.  Use the `-p`/`--profile` flag to select a
+build style:
 
 # Developer build (debug symbols + warnings)
 ./build.sh
@@ -103,10 +105,10 @@ For an even simpler one-command build, use our Bash helper:
 # Performance-tuned build
 ./build.sh -p performance
 
-# Release-style build (O2, stripped)
+# Release-style build
 ./build.sh -p release
 
-Inspect build.sh to see which CFLAGS each profile applies.
+Run `./build.sh -h` for a brief summary of the profiles and flags.
 
 ⸻
 

--- a/build.sh
+++ b/build.sh
@@ -1,56 +1,59 @@
-#!/bin/sh
-# build.sh - Compile all project components using existing makefiles.
+#!/usr/bin/env bash
+# build.sh - iterate through subdirectory makefiles with selectable profiles
 #
 # Usage: ./build.sh [-p PROFILE]
-#   PROFILE can be one of the following:
-#       developer  - Debug build with no optimizations.
-#       performance- Optimized build for development testing.
-#       release    - Fully optimized build stripped of symbols.
-# The default profile is 'developer'.
-
+#
+# Profiles:
+#   developer    -O0 -g -Wall (default)
+#   performance  -O2 -pipe -march=native -Wall
+#   release      -O2 -pipe -march=native -DNDEBUG -Wall -s
+#
+# The script searches the `src/` and `upgrade/` trees for any Makefile and
+# invokes `make` within each directory using the profile's CFLAGS.
+#
+# Example:
+#   ./build.sh                # developer profile
+#   ./build.sh -p performance # tuned build
+#   ./build.sh -p release     # production build
+#
 set -e
 
 profile=developer
 
+usage() {
+    sed -n '2,16p' "$0"
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
         -p|--profile)
-            profile="$2"
-            shift 2
-            ;;
+            profile="$2"; shift 2;;
         -h|--help)
-            sed -n '2,10p' "$0"
-            exit 0
-            ;;
+            usage; exit 0;;
         *)
             echo "Unknown option: $1" >&2
-            sed -n '2,10p' "$0"
-            exit 1
-            ;;
+            usage; exit 1;;
     esac
 done
 
 case "$profile" in
     developer)
-        CFLAGS="-O0 -g" ;;
+        CFLAGS="-O0 -g -Wall";;
     performance)
-        CFLAGS="-O2 -march=native" ;;
+        CFLAGS="-O2 -pipe -march=native -Wall";;
     release)
-        CFLAGS="-O2 -march=native -DNDEBUG" ;;
+        CFLAGS="-O2 -pipe -march=native -DNDEBUG -Wall -s";;
     *)
         echo "Invalid profile: $profile" >&2
-        exit 1
-        ;;
+        exit 1;;
 esac
 
-printf 'Using profile %s (CFLAGS=%s)\n' "$profile" "$CFLAGS"
+echo "Using profile '$profile' (CFLAGS='$CFLAGS')"
 
-# Find all directories that contain a makefile and build them.
-find . -type f -iname "makefile*" -exec dirname {} \; | sort -u | while read -r dir; do
-    (cd "$dir" && make CFLAGS="$CFLAGS")
-    if [ $? -ne 0 ]; then
-        echo "=== Failed to build $dir ===" >&2
-    else
-        echo "=== Done $dir ==="
-    fi
+# Collect directories containing Makefiles under src/ and upgrade/
+find src upgrade -type f -iname 'makefile*' -printf '%h\n' | sort -u |
+while read -r dir; do
+    echo "=== Building $dir ==="
+    make -C "$dir" CFLAGS="$CFLAGS"
 done
+


### PR DESCRIPTION
## Summary
- add a new `build.sh` script that walks through subdirectories and runs their makefiles
- document the build profiles in `README.md`

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688af7227a408331a5f97c7b925944e6